### PR TITLE
add client-server scenario without port changes

### DIFF
--- a/local/client-server/README.md
+++ b/local/client-server/README.md
@@ -1,0 +1,17 @@
+# Setting up Consul server  and client agents on the same machine
+While Consul in `dev` mode acts as both a server agent and a client agent, there are scenarios (for example, testing anti-entropy) in which you would like to test the interaction between a client and a server.  
+
+
+## Prerequisite
+You need to create a second loopback address to be able to use the same ports. 
+In MacOS: 
+
+```bash 
+sudo ifconfig lo0 alias 127.0.0.2 up
+```
+
+Then run `run.sh`. To point to the client agent you can use `CONSUL_HTTP_ADDR` variable, For example: 
+
+```bash
+CONSUL_HTTP_ADDR="http://127.0.0.2:8500" consul services register <service>.hcl
+```

--- a/local/client-server/client.hcl
+++ b/local/client-server/client.hcl
@@ -1,0 +1,7 @@
+server = false
+bind_addr = "127.0.0.2"
+client_addr = "127.0.0.2"
+advertise_addr = "127.0.0.2"
+node_name = "client"
+data_dir = "tmp/data"
+retry_join = ["127.0.0.1"]

--- a/local/client-server/run.sh
+++ b/local/client-server/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+mkdir -p logs
+mkdir -p tmp/data
+
+# start the server 
+consul agent -dev 1>./logs/server.log &
+
+# start the client 
+consul agent -dev -config-file client.hcl 1>./logs/client.log & 


### PR DESCRIPTION
This scenario creates a Consul server and a client on a local machine without the need to change default ports.  